### PR TITLE
Bug in JDBCStorageDelegate that leads to ResultSet been closed

### DIFF
--- a/src/main/java/io/vlingo/symbio/store/state/jdbc/JDBCStorageDelegate.java
+++ b/src/main/java/io/vlingo/symbio/store/state/jdbc/JDBCStorageDelegate.java
@@ -290,48 +290,28 @@ public abstract class JDBCStorageDelegate<T> implements StorageDelegate,
 
   @SuppressWarnings("unchecked")
   public <R> R readAllExpressionFor(final String storeName) throws Exception {
-    final String storeNameKey = "ALL:"+storeName;
-
-    final CachedStatement<T> maybeCached = readStatements.get(storeNameKey);
-
-    if (maybeCached == null) {
-      final String select = readAllExpression(storeName);
-      final PreparedStatement preparedStatement =
-              connection.prepareStatement(
-                      select,
-                      ResultSet.TYPE_SCROLL_INSENSITIVE,
-                      ResultSet.CONCUR_READ_ONLY);
-      final CachedStatement<T> cached = new CachedStatement<>(preparedStatement, null);
-      readStatements.put(storeNameKey, cached);
-      prepareForReadAll(cached);
-      return (R) preparedStatement;
-    }
-
-    prepareForReadAll(maybeCached);
-
-    return (R) maybeCached.preparedStatement;
+    
+    final String select = readAllExpression(storeName);
+    final PreparedStatement preparedStatement =
+            connection.prepareStatement(
+                    select,
+                    ResultSet.TYPE_SCROLL_INSENSITIVE,
+                    ResultSet.CONCUR_READ_ONLY);
+    preparedStatement.clearParameters();
+    return (R) preparedStatement;
   }
 
   @SuppressWarnings("unchecked")
   public <R> R readExpressionFor(final String storeName, final String id) throws Exception {
-    final CachedStatement<T> maybeCached = readStatements.get(storeName);
-
-    if (maybeCached == null) {
+	 
       final String select = readExpression(storeName, id);
       final PreparedStatement preparedStatement =
               connection.prepareStatement(
                       select,
                       ResultSet.TYPE_SCROLL_INSENSITIVE,
                       ResultSet.CONCUR_READ_ONLY);
-      final CachedStatement<T> cached = new CachedStatement<>(preparedStatement, null);
-      readStatements.put(storeName, cached);
-      prepareForRead(cached, id);
+      preparedStatement.setString(1, id);
       return (R) preparedStatement;
-    }
-
-    prepareForRead(maybeCached, id);
-
-    return (R) maybeCached.preparedStatement;
   }
 
   @SuppressWarnings("unchecked")
@@ -541,14 +521,14 @@ public abstract class JDBCStorageDelegate<T> implements StorageDelegate,
     }
   }
 
-  private void prepareForReadAll(final CachedStatement<T> cached) throws Exception {
-    cached.preparedStatement.clearParameters();
-  }
-
-  private void prepareForRead(final CachedStatement<T> cached, final String id) throws Exception {
-    cached.preparedStatement.clearParameters();
-    cached.preparedStatement.setString(1, id);
-  }
+//  private void prepareForReadAll(final CachedStatement<T> cached) throws Exception {
+//    cached.preparedStatement.clearParameters();
+//  }
+//
+//  private void prepareForRead(final CachedStatement<T> cached, final String id) throws Exception {
+//    cached.preparedStatement.clearParameters();
+//    cached.preparedStatement.setString(1, id);
+//  }
 
   private <E> void prepareForAppend(final CachedStatement<T> cached, final Entry<E> entry) throws Exception {
     cached.preparedStatement.clearParameters();

--- a/src/main/java/io/vlingo/symbio/store/state/jdbc/JDBCStorageDelegate.java
+++ b/src/main/java/io/vlingo/symbio/store/state/jdbc/JDBCStorageDelegate.java
@@ -297,7 +297,6 @@ public abstract class JDBCStorageDelegate<T> implements StorageDelegate,
                     select,
                     ResultSet.TYPE_SCROLL_INSENSITIVE,
                     ResultSet.CONCUR_READ_ONLY);
-    preparedStatement.clearParameters();
     return (R) preparedStatement;
   }
 
@@ -520,15 +519,6 @@ public abstract class JDBCStorageDelegate<T> implements StorageDelegate,
       }
     }
   }
-
-//  private void prepareForReadAll(final CachedStatement<T> cached) throws Exception {
-//    cached.preparedStatement.clearParameters();
-//  }
-//
-//  private void prepareForRead(final CachedStatement<T> cached, final String id) throws Exception {
-//    cached.preparedStatement.clearParameters();
-//    cached.preparedStatement.setString(1, id);
-//  }
 
   private <E> void prepareForAppend(final CachedStatement<T> cached, final Entry<E> entry) throws Exception {
     cached.preparedStatement.clearParameters();


### PR DESCRIPTION
### Problem:

The methods `readAllExpressionFor` and `readExpressionFor` take as parameter a String `storeName` and base on the pass in argument `storeName`  a new `PreparedStatement` is created and cached if no request has been made to that `storeName` yet else a cached `PreparedStatement` with that `storeName` is returned, after which the `PreparedStatement` is used to execute a query.

So in a scenario where multiple concurrent processes are calling the methods with the same `storeName` argument, they will all get the same `PreparedStatement`.

According to the Postgres JDBC Documentation, a `ResultSet` is
automatically closed When the `Statement` used to create it, send another
query.
[Postgres JDBC Documentation Link](https://jdbc.postgresql.org/documentation/head/resultset.html)

**Note:  I can not confirm if this applies to other JDBC Drivers**

The problem here is that When a process A is in the midst of reading data from a `ResultSet` that was created with a particular `PreparedStatement` and another process B sends a new query with the same `PreparedStatement`, the `ResultSet` of the process A will automatically be closed leading to process A throwing a `PSQLException` (This ResultSet is closed).

### Solution:

Removed CachedStatement from the methods `readAllExpressionFor` and
`readExpressionFor` so that new `PreparedStatement` is returned every time.

Removing the `CachedStatement` from the methods guarantees that every
process will get a new `PreparedStatement`, therefore it will not
interrupt the `ResultSet` of another.

### Origin:
This Bug was discovered while performing a load Test on Vlingo-Helloword App with Gatling
the Scenario was as follows:

First: post a new greeting:
check response is 201 OK
pause 800 milliseconds

Second: get the newly save greeting
check response is 200 OK
pause 800 milliseconds

Third: get all greetings
check response is 200 OK
Pause 800 milliseconds

with 1000 concurrentUsersPerseconds.



