### PR TITLE
Store the created on date in milliseconds as it is later read in milliseconds

### DIFF
--- a/src/main/java/io/vlingo/symbio/store/journal/jdbc/JDBCQueries.java
+++ b/src/main/java/io/vlingo/symbio/store/journal/jdbc/JDBCQueries.java
@@ -166,7 +166,7 @@ public abstract class JDBCQueries {
 
         insertDispatchable.setString(1, d_dispatch_id);
         insertDispatchable.setString(2, d_originator_id);
-        insertDispatchable.setLong(3, System.nanoTime());
+        insertDispatchable.setLong(3, System.currentTimeMillis());
 
         insertDispatchable.setString(4, d_state_id);
         insertDispatchable.setString(5, d_state_data);

--- a/src/test/java/io/vlingo/symbio/store/journal/jdbc/JDBCJournalActorTest.java
+++ b/src/test/java/io/vlingo/symbio/store/journal/jdbc/JDBCJournalActorTest.java
@@ -80,7 +80,7 @@ public abstract class JDBCJournalActorTest extends BaseJournalTest {
                                 dispatcherControlDelegate,
                                 // do not allow timeouts to occur
                                 2_000L,
-                                1_200_000L)));
+                                5_000L)));
 
         journal = journalFrom(world, configuration, Collections.singletonList(typed(dispatcher)), dispatcherControl);
         EntryAdapterProvider.instance(world).registerAdapter(TestEvent.class, new TestEventAdapter());


### PR DESCRIPTION
The problem was discovered when running tests with a slow database. Dispatchables were re-dispatched again as the expiration interval was always lower than nanoseconds read as milliseconds.